### PR TITLE
Change Legend Position

### DIFF
--- a/octoprint_sidebartempgraph/static/js/sidebartempgraph.js
+++ b/octoprint_sidebartempgraph/static/js/sidebartempgraph.js
@@ -313,7 +313,7 @@ $(function() {
                     }
                 },
                 legend: {
-                    position: "sw",
+                    position: "nw",
                     noColumns: 2,
                     backgroundOpacity: 0
                 }

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_sidebartempgraph"
 plugin_name = "OctoPrint-SibeBarTempGraph"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.1"
+plugin_version = "0.1.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
@@ -67,7 +67,8 @@ try:
 	import octoprint_setuptools
 except:
 	print("Could not import OctoPrint's setuptools, are you sure you are running that under "
-	      "the same python installation that OctoPrint is installed under?")
+	      "the same python installation that OctoPrint is installed under?"
+	      "(Maybe try \"/home/pi/oprint/bin/pip\" instead?)")
 	import sys
 	sys.exit(-1)
 


### PR DESCRIPTION
On my version of Octoprint, the legend for the sidebar graph was useless because the bed temperature and nozzle temperature lines seemed to always cover up the actual temperature numbers. This PR moves that legend up to the top left of the graph and bumps the version up a bit.