### PR TITLE
Recommend OctoPrint-DragonOrder instead of OctoPrint-SidebarOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Small plugin that adds a temperature graph to the sidebar.  
 
-**Note:** To change the location of the graph within the Sidebar install [OctoPrint-SidebarOrder](https://github.com/zoombahh/OctoPrint-SidebarOrder) plugin. Use `plugin_sidebartempgraph` for the sidebar identifier in that plugin's settings.
+**Note:** To change the location of the graph within the Sidebar install [OctoPrint-DragonOrder](https://github.com/jneilliii/OctoPrint-DragonOrder) plugin.
 
 ### Screenshot
 


### PR DESCRIPTION
According to https://github.com/zoombahh/OctoPrint-SidebarOrder/pull/4 it is not Python 3-compatible and @zoombahh recommends OctoPrint-SidebarOrder instead.